### PR TITLE
[#5679] Prevent nil errors on the attributes

### DIFF
--- a/lib/state_machines/machine_collection.rb
+++ b/lib/state_machines/machine_collection.rb
@@ -20,6 +20,8 @@ module StateMachines
     # * <tt>:to</tt> - A hash to write the initialized state to instead of
     #   writing to the object.  Default is to write directly to the object.
     def initialize_states(object, options = {}, attributes = {})
+      attributes ||= {}
+
       options.assert_valid_keys( :static, :dynamic, :to)
       options = {:static => true, :dynamic => true}.merge(options)
 

--- a/lib/state_machines/version.rb
+++ b/lib/state_machines/version.rb
@@ -1,3 +1,3 @@
 module StateMachines
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
Issue [#5679](https://github.com/wildlife-conservation-society/wcs/issues/5679)

- Set `attributes` to the default value of `{}` when `nil` in the `initialize_states` method of `machine_collection.rb`.